### PR TITLE
feat(interruptsource): allow interrupts to use an ssr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export class AppComponent implements OnInit {
     this.idle.setIdle(60 * 10);
 
     // create your interrupts. DO NOT use DEFAULT_INTERRUPTSOURCES for ssr/univeral apps!
-    const myInterrupts = new DocumentInterruptSource({ ssr: isPlatformServer(platform) });
+    const myInterrupts = new DocumentInterruptSource('mousedown', { ssr: isPlatformServer(platform) });
     // OR, you can use createDefaultInterruptSources and pass in the ssr option
     // const myInterrupts = createDefaultInterruptSources({ ssr: isPlatformServer(platform) });
 

--- a/projects/core/src/lib/defaultinterruptsources.ts
+++ b/projects/core/src/lib/defaultinterruptsources.ts
@@ -10,8 +10,8 @@ export function createDefaultInterruptSources(
       'mousemove keydown DOMMouseScroll mousewheel mousedown touchstart touchmove scroll',
       options
     ),
-    new StorageInterruptSource()
+    new StorageInterruptSource(options)
   ];
 }
 
-export const DEFAULT_INTERRUPTSOURCES: any[] = createDefaultInterruptSources();
+export const DEFAULT_INTERRUPTSOURCES = createDefaultInterruptSources();

--- a/projects/core/src/lib/documentinterruptsource.spec.ts
+++ b/projects/core/src/lib/documentinterruptsource.spec.ts
@@ -16,6 +16,19 @@ describe('core/DocumentInterruptSource', () => {
     source.detach();
   }));
 
+  it('does not emit events when ssr option is true', fakeAsync(() => {
+    const source = new DocumentInterruptSource('click', { ssr: true });
+    spyOn(source.onInterrupt, 'emit').and.callThrough();
+    source.attach();
+
+    const expected = new Event('click');
+    document.documentElement.dispatchEvent(expected);
+
+    expect(source.onInterrupt.emit).not.toHaveBeenCalled();
+
+    source.detach();
+  }));
+
   it('does not emit onInterrupt event when detached and event is fired', fakeAsync(() => {
     const source = new DocumentInterruptSource('click');
     spyOn(source.onInterrupt, 'emit').and.callThrough();

--- a/projects/core/src/lib/documentinterruptsource.ts
+++ b/projects/core/src/lib/documentinterruptsource.ts
@@ -1,3 +1,6 @@
+import { Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
 import {
   EventTargetInterruptOptions,
   EventTargetInterruptSource
@@ -8,7 +11,13 @@ import {
  */
 export class DocumentInterruptSource extends EventTargetInterruptSource {
   constructor(events: string, options?: number | EventTargetInterruptOptions) {
-    super(document.documentElement, events, options);
+    const target =
+      options && (options as EventTargetInterruptOptions).ssr
+        ? null
+        : document.documentElement;
+
+    options = !options || typeof options === 'number' ? {} : options;
+    super(target, events, options);
   }
 
   /*

--- a/projects/core/src/lib/eventtargetinterruptsource.spec.ts
+++ b/projects/core/src/lib/eventtargetinterruptsource.spec.ts
@@ -43,6 +43,36 @@ describe('core/EventTargetInterruptSource', () => {
     expect(source.onInterrupt.emit).not.toHaveBeenCalled();
   }));
 
+  it('does not emit onInterrupt event when ssr is true', fakeAsync(() => {
+    const source = new EventTargetInterruptSource(document.body, 'click', {
+      ssr: true
+    });
+    spyOn(source.onInterrupt, 'emit').and.callThrough();
+
+    source.attach();
+
+    const expected = new Event('click');
+    document.body.dispatchEvent(expected);
+
+    expect(source.onInterrupt.emit).not.toHaveBeenCalled();
+
+    source.detach();
+  }));
+
+  it('does not emit onInterrupt event when target is null', fakeAsync(() => {
+    const source = new EventTargetInterruptSource(null, 'click');
+    spyOn(source.onInterrupt, 'emit').and.callThrough();
+
+    source.attach();
+
+    const expected = new Event('click');
+    document.body.dispatchEvent(expected);
+
+    expect(source.onInterrupt.emit).not.toHaveBeenCalled();
+
+    source.detach();
+  }));
+
   it('should throttle target events using the specified throttleDelay value', fakeAsync(() => {
     const source = new EventTargetInterruptSource(document.body, 'click', 500);
     spyOn(source.onInterrupt, 'emit').and.callThrough();
@@ -97,10 +127,11 @@ describe('core/EventTargetInterruptSource', () => {
   it('should set default options', () => {
     const target = {};
     const source = new EventTargetInterruptSource(target, 'click');
-    const { throttleDelay, passive } = source.options;
+    const { throttleDelay, passive, ssr } = source.options;
 
     expect(passive).toBeFalsy();
     expect(throttleDelay).toBe(500);
+    expect(ssr).toBeFalsy();
   });
 
   it('should set passive flag', () => {
@@ -108,10 +139,11 @@ describe('core/EventTargetInterruptSource', () => {
     const source = new EventTargetInterruptSource(target, 'click', {
       passive: true
     });
-    const { throttleDelay, passive } = source.options;
+    const { throttleDelay, passive, ssr: isBrowser } = source.options;
 
     expect(passive).toBeTruthy();
     expect(throttleDelay).toBe(500);
+    expect(isBrowser).toBeFalsy();
   });
 
   it('should set throttleDelay', () => {
@@ -119,21 +151,24 @@ describe('core/EventTargetInterruptSource', () => {
     const source = new EventTargetInterruptSource(target, 'click', {
       throttleDelay: 1000
     });
-    const { throttleDelay, passive } = source.options;
+    const { throttleDelay, passive, ssr } = source.options;
 
     expect(passive).toBeFalsy();
     expect(throttleDelay).toBe(1000);
+    expect(ssr).toBeFalsy();
   });
 
-  it('should set both options', () => {
+  it('should set all options', () => {
     const target = {};
     const source = new EventTargetInterruptSource(target, 'click', {
-      throttleDelay: 1000,
-      passive: true
+      passive: true,
+      ssr: true,
+      throttleDelay: 1000
     });
-    const { throttleDelay, passive } = source.options;
+    const { throttleDelay, passive, ssr } = source.options;
 
     expect(passive).toBeTruthy();
     expect(throttleDelay).toBe(1000);
+    expect(ssr).toBeTruthy();
   });
 });

--- a/projects/core/src/lib/eventtargetinterruptsource.ts
+++ b/projects/core/src/lib/eventtargetinterruptsource.ts
@@ -18,6 +18,12 @@ export interface EventTargetInterruptOptions {
    * Note: you need to detect if the browser supports passive listeners, and only set this to true if it does.
    */
   passive?: boolean;
+
+  /**
+   * Whether or not the app is running on the server side or non-browser context where access
+   * to browser globals and user input is not possible.
+   */
+  ssr?: boolean;
 }
 
 const defaultThrottleDelay = 500;
@@ -30,6 +36,7 @@ export class EventTargetInterruptSource extends InterruptSource {
   private eventSubscription: Subscription = new Subscription();
   protected throttleDelay: number;
   protected passive: boolean;
+  protected ssr: boolean;
 
   constructor(
     protected target: any,
@@ -39,12 +46,13 @@ export class EventTargetInterruptSource extends InterruptSource {
     super(null, null);
 
     if (typeof options === 'number') {
-      options = { throttleDelay: options, passive: false };
+      options = { throttleDelay: options, passive: false, ssr: false };
     }
 
     options = options || {
-      throttleDelay: defaultThrottleDelay,
-      passive: false
+      passive: false,
+      ssr: false,
+      throttleDelay: defaultThrottleDelay
     };
 
     if (options.throttleDelay === undefined || options.throttleDelay === null) {
@@ -53,6 +61,11 @@ export class EventTargetInterruptSource extends InterruptSource {
 
     this.throttleDelay = options.throttleDelay;
     this.passive = !!options.passive;
+    this.ssr = !!options.ssr;
+
+    if (this.ssr || !target) {
+      return;
+    }
 
     const opts = this.passive ? { passive: true } : null;
     const fromEvents = events
@@ -89,6 +102,10 @@ export class EventTargetInterruptSource extends InterruptSource {
    * @return The current option values.
    */
   get options(): EventTargetInterruptOptions {
-    return { throttleDelay: this.throttleDelay, passive: this.passive };
+    return {
+      passive: this.passive,
+      ssr: this.ssr,
+      throttleDelay: this.throttleDelay
+    };
   }
 }

--- a/projects/core/src/lib/storageinterruptsource.spec.ts
+++ b/projects/core/src/lib/storageinterruptsource.spec.ts
@@ -57,4 +57,18 @@ describe('core/StorageInterruptSource', () => {
 
     source.detach();
   }));
+
+  it('does not emit onInterrupt event when ssr is true', fakeAsync(() => {
+    const source = new StorageInterruptSource({ ssr: true });
+    spyOn(source.onInterrupt, 'emit').and.callThrough();
+
+    source.attach();
+
+    const expected = new StorageEvent('storage');
+    window.dispatchEvent(expected);
+
+    expect(source.onInterrupt.emit).not.toHaveBeenCalled();
+
+    source.detach();
+  }));
 });

--- a/projects/core/src/lib/storageinterruptsource.ts
+++ b/projects/core/src/lib/storageinterruptsource.ts
@@ -1,11 +1,12 @@
 import { WindowInterruptSource } from './windowinterruptsource';
+import { EventTargetInterruptOptions } from './eventtargetinterruptsource';
 
 /*
  * An interrupt source on the storage event of Window.
  */
 export class StorageInterruptSource extends WindowInterruptSource {
-  constructor(throttleDelay = 500) {
-    super('storage', throttleDelay);
+  constructor(options: number | EventTargetInterruptOptions = 500) {
+    super('storage', options);
   }
 
   /*

--- a/projects/core/src/lib/windowinterruptsource.spec.ts
+++ b/projects/core/src/lib/windowinterruptsource.spec.ts
@@ -29,4 +29,18 @@ describe('core/WindowInterruptSource', () => {
 
     expect(source.onInterrupt.emit).not.toHaveBeenCalled();
   }));
+
+  it('does not emit onInterrupt event when ssr is true', fakeAsync(() => {
+    const source = new WindowInterruptSource('focus', { ssr: true });
+    spyOn(source.onInterrupt, 'emit').and.callThrough();
+
+    source.attach();
+
+    const expected = new Event('focus');
+    window.dispatchEvent(expected);
+
+    expect(source.onInterrupt.emit).not.toHaveBeenCalled();
+
+    source.detach();
+  }));
 });

--- a/projects/core/src/lib/windowinterruptsource.ts
+++ b/projects/core/src/lib/windowinterruptsource.ts
@@ -8,6 +8,9 @@ import {
  */
 export class WindowInterruptSource extends EventTargetInterruptSource {
   constructor(events: string, options?: number | EventTargetInterruptOptions) {
-    super(window, events, options);
+    const target =
+      options && (options as EventTargetInterruptOptions).ssr ? null : window;
+
+    super(target, events, options);
   }
 }


### PR DESCRIPTION
ssr option instructs interrupt sources to ignore targets
derived from global context such as window or document so
they can be safely used in ssr/universal apps.

If you are using ssr/universal, do not use
DEFAULT_INTERRUPTSOURCES. Instead, use
`createDefaultInterruptSources({ssr: !isPlatformBrowser(platformId) })`.
 See docs or https://stackoverflow.com/a/46893433/64750
for information on how to use isPlatformBrowser.

Fixes #77, #115

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

No support for SSR/Universal apps.


**What is the new behavior?**
Adds an opt-in option when creating interrupt sources that will allow compatibility with SSR/universal.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
